### PR TITLE
Simplify runner labels: use 'self-hosted' only (no array syntax)

### DIFF
--- a/.github/workflows/build-templates.yml
+++ b/.github/workflows/build-templates.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   validate:
     name: Validate Windows 2022
-    runs-on: [self-hosted]
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
 
   build-packer:
     name: Build Windows 2022 Template
-    runs-on: [self-hosted]
+    runs-on: self-hosted
     needs: validate
     steps:
       - name: Checkout
@@ -96,7 +96,7 @@ jobs:
 
   terraform-test:
     name: Terraform Test (Optional)
-    runs-on: [self-hosted]
+    runs-on: self-hosted
     needs: build-packer
     if: |
       always() && 
@@ -130,7 +130,7 @@ jobs:
 
   notify:
     name: Notify Results
-    runs-on: [self-hosted]
+    runs-on: self-hosted
     needs: [build-packer, terraform-test]
     if: always()
     steps:

--- a/.github/workflows/discover-nodes.yml
+++ b/.github/workflows/discover-nodes.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   discover:
     name: Discover Proxmox Node Names
-    runs-on: [self-hosted]
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
- Change from runs-on: [self-hosted] to runs-on: self-hosted
- This should work with any self-hosted runner regardless of additional labels